### PR TITLE
Upgrade Jinja2 support for webapp2

### DIFF
--- a/docs/api/webapp2_extras/i18n.rst
+++ b/docs/api/webapp2_extras/i18n.rst
@@ -13,7 +13,7 @@ environment (for other servers).
 You can download ``babel`` and ``pytz`` from the following locations:
 
     http://babel.edgewall.org/
-    http://pypi.python.org/pypi/gaepytz
+    http://pypi.python.org/pypi/pytz
 
 .. autodata:: default_config
 

--- a/docs/tutorials/i18n.rst
+++ b/docs/tutorials/i18n.rst
@@ -17,8 +17,8 @@ If you don't have a package installer in your system yet (like ``pip`` or
 
 Get Babel and Pytz
 ------------------
-The i18n module depends on two libraries: ``babel`` and ``pytz`` (or
-``gaepytz``). So before we start you must add the ``babel`` and ``pytz``
+The i18n module depends on two libraries: ``babel`` and ``pytz``.
+So before we start you must add the ``babel`` and ``pytz``
 packages to your application directory (for App Engine) or install it in your
 virtual environment (for other servers).
 
@@ -26,7 +26,7 @@ For App Engine, download ``babel`` and ``pytz`` and add those libraries to
 your app directory:
 
 - Babel: http://babel.edgewall.org/
-- Pytz: http://pypi.python.org/pypi/gaepytz
+- Pytz: http://pypi.python.org/pypi/pytz
 
 For other servers, install those libraries in your system using ``pip``.
 App Engine users also need babel installed, as we use the command line
@@ -36,14 +36,14 @@ This assumes a `*nix` environment:
 .. code-block:: text
 
    $ sudo pip install babel
-   $ sudo pip install gaepytz
+   $ sudo pip install pytz
 
 Or, if you don't have pip but have ``easy_install``:
 
 .. code-block:: text
 
    $ sudo easy_install babel
-   $ sudo easy_install gaepytz
+   $ sudo easy_install pytz
 
 
 Create a directory for translations

--- a/requirements-dev-gaesdk.txt
+++ b/requirements-dev-gaesdk.txt
@@ -1,14 +1,15 @@
 # These requirements versions match what's provided by the app engine sdk.
-WebOb==1.2.3
-Jinja2==2.6.0
+webob==1.8.9
+jinja2==3.1.6
 # The remaining requirements are defined by webapp2. These are the versions
 # that were used with release 2.5.2, except for babel.
-six==1.10.0
-Mako==0.4.1
-Babel==2.2
-gaepytz==2011h
+six==1.17.0
+mako==1.3.10
+babel==2.17.0
+pytz==2025.2
+python-dateutil==2.9.0.post0
 # Test dependencies.
-pytest==2.9.1
-pytest-cov==2.2.1
-mock==2.0.0
-gcp-devrel-py-tools==0.0.8
+pytest==7.4.4
+pytest-cov==4.1.0
+mock==5.1.0
+gcp-devrel-py-tools==0.0.16

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,4 @@ mock==5.1.0
 six==1.17.0
 gcp-devrel-py-tools==0.0.16
 greenlet==3.2.4
+ruff==0.13.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,14 @@
 # These dependencies match App Engine SDK versions.
-WebOb==1.6.1
-Jinja2==2.8
-Mako==1.0.4
-Babel==2.3.4
-pytz==2016.6.1
+webob==1.8.9
+jinja2==3.1.6
+mako==1.3.10
+babel==2.17.0
+pytz==2025.2
+python-dateutil==2.9.0.post0
 # These are test dependencies
-pytest==2.9.1
-pytest-cov==2.2.1
-mock==2.0.0
-six==1.10.0
-gcp-devrel-py-tools==0.0.8
+pytest==7.4.4
+pytest-cov==4.1.0
+mock==5.1.0
+six==1.17.0
+gcp-devrel-py-tools==0.0.16
+greenlet==3.2.4

--- a/setup.py
+++ b/setup.py
@@ -20,21 +20,22 @@ from setuptools import setup
 LONG_DESCRIPTION = open('README.rst', 'r', encoding='utf-8').read()
 
 REQUIREMENTS = [
-    'webob>=1.2.0',
-    'six>=1.10.0'
+    'webob>=1.8',
+    'six>=1.17'
 ]
 
 EXTRA_REQUIREMENTS = {
-    'jinja2>=2.4',
-    'Babel>=2.2',
-    'pytz>=2015.7'
+    'jinja2>=3.1,<4.0',
+    'babel>=2.17',
+    'pytz>=2025.2',
+    'python-dateutil>=2.9',
 }
 
 setup(
     name='webapp2',
-    version='3.0.0b1',
+    version='3.0.0rc495',
     license='Apache Software License',
-    url='http://webapp2.readthedocs.org',
+    url='https://webapp2.readthedocs.org',
     description="Taking Google App Engine's webapp to the next level!",
     long_description=LONG_DESCRIPTION,
     author='The Webapp2 Maintainers',

--- a/tests/extras_i18n_test.py
+++ b/tests/extras_i18n_test.py
@@ -24,12 +24,11 @@ from webapp2_extras import i18n
 
 
 class I18nTestCase(unittest.TestCase):
-
     def setUp(self):
         super(I18nTestCase, self).setUp()
 
         app = webapp2.WSGIApplication()
-        request = webapp2.Request.blank('/')
+        request = webapp2.Request.blank("/")
         request.app = app
 
         app.set_globals(app=app, request=request)
@@ -44,62 +43,50 @@ class I18nTestCase(unittest.TestCase):
     def test_translations_not_set(self):
         # We release it here because it is set on setUp()
         self.app.clear_globals()
-        self.assertRaises(AssertionError, i18n.gettext, 'foo')
+        self.assertRaises(AssertionError, i18n.gettext, "foo")
 
     def test_gettext(self):
-        self.assertEqual(i18n.gettext('foo'), u'foo')
+        self.assertEqual(i18n.gettext("foo"), "foo")
 
     def test_gettext_(self):
-        self.assertEqual(i18n._('foo'), u'foo')
+        self.assertEqual(i18n._("foo"), "foo")
 
     def test_gettext_with_variables(self):
-        self.assertEqual(i18n.gettext('foo %(foo)s'), u'foo %(foo)s')
-        self.assertEqual(
-            i18n.gettext('foo %(foo)s') % {'foo': 'bar'},
-            u'foo bar'
-        )
-        self.assertEqual(i18n.gettext('foo %(foo)s', foo='bar'), u'foo bar')
+        self.assertEqual(i18n.gettext("foo %(foo)s"), "foo %(foo)s")
+        self.assertEqual(i18n.gettext("foo %(foo)s") % {"foo": "bar"}, "foo bar")
+        self.assertEqual(i18n.gettext("foo %(foo)s", foo="bar"), "foo bar")
 
     def test_ngettext(self):
-        self.assertEqual(i18n.ngettext('One foo', 'Many foos', 1), u'One foo')
-        self.assertEqual(
-            i18n.ngettext('One foo', 'Many foos', 2),
-            u'Many foos'
-        )
+        self.assertEqual(i18n.ngettext("One foo", "Many foos", 1), "One foo")
+        self.assertEqual(i18n.ngettext("One foo", "Many foos", 2), "Many foos")
 
     def test_ngettext_with_variables(self):
         self.assertEqual(
-            i18n.ngettext('One foo %(foo)s', 'Many foos %(foo)s', 1),
-            u'One foo %(foo)s'
+            i18n.ngettext("One foo %(foo)s", "Many foos %(foo)s", 1), "One foo %(foo)s"
         )
         self.assertEqual(
-            i18n.ngettext('One foo %(foo)s', 'Many foos %(foo)s', 2),
-            u'Many foos %(foo)s'
+            i18n.ngettext("One foo %(foo)s", "Many foos %(foo)s", 2),
+            "Many foos %(foo)s",
         )
         self.assertEqual(
-            i18n.ngettext(
-                'One foo %(foo)s', 'Many foos %(foo)s', 1,
-                foo='bar'),
-            u'One foo bar'
+            i18n.ngettext("One foo %(foo)s", "Many foos %(foo)s", 1, foo="bar"),
+            "One foo bar",
         )
         self.assertEqual(
-            i18n.ngettext('One foo %(foo)s', 'Many foos %(foo)s', 2,
-                          foo='bar'),
-            u'Many foos bar'
+            i18n.ngettext("One foo %(foo)s", "Many foos %(foo)s", 2, foo="bar"),
+            "Many foos bar",
         )
         self.assertEqual(
-            i18n.ngettext(
-                'One foo %(foo)s', 'Many foos %(foo)s', 1) % {'foo': 'bar'},
-            u'One foo bar'
+            i18n.ngettext("One foo %(foo)s", "Many foos %(foo)s", 1) % {"foo": "bar"},
+            "One foo bar",
         )
         self.assertEqual(
-            i18n.ngettext(
-                'One foo %(foo)s', 'Many foos %(foo)s', 2) % {'foo': 'bar'},
-            u'Many foos bar'
+            i18n.ngettext("One foo %(foo)s", "Many foos %(foo)s", 2) % {"foo": "bar"},
+            "Many foos bar",
         )
 
     def test_lazy_gettext(self):
-        self.assertEqual(i18n.lazy_gettext('foo'), u'foo')
+        self.assertEqual(i18n.lazy_gettext("foo"), "foo")
 
     # ==========================================================================
     # Date formatting
@@ -108,23 +95,18 @@ class I18nTestCase(unittest.TestCase):
     def test_format_date(self):
         value = datetime.datetime(2009, 11, 10, 16, 36, 5)
 
-        self.assertEqual(i18n.format_date(value, format='short'), u'11/10/09')
+        self.assertEqual(i18n.format_date(value, format="short"), "11/10/09")
+        self.assertEqual(i18n.format_date(value, format="medium"), "Nov 10, 2009")
+        self.assertEqual(i18n.format_date(value, format="long"), "November 10, 2009")
         self.assertEqual(
-            i18n.format_date(value, format='medium'), u'Nov 10, 2009'
-        )
-        self.assertEqual(
-            i18n.format_date(value, format='long'), u'November 10, 2009'
-        )
-        self.assertEqual(
-            i18n.format_date(value, format='full'),
-            u'Tuesday, November 10, 2009'
+            i18n.format_date(value, format="full"), "Tuesday, November 10, 2009"
         )
 
     def test_format_date_no_format(self):
         value = datetime.datetime(2009, 11, 10, 16, 36, 5)
-        self.assertEqual(i18n.format_date(value), u'Nov 10, 2009')
+        self.assertEqual(i18n.format_date(value), "Nov 10, 2009")
 
-    '''
+    """
     def test_format_date_no_format_but_configured(self):
         app = App(config={
             'tipfy.sessions': {
@@ -159,214 +141,183 @@ class I18nTestCase(unittest.TestCase):
             i18n.format_date(value),
             u'Tuesday, November 10, 2009'
         )
-    '''
+    """
 
     def test_format_date_pt_BR(self):
-        i18n.get_i18n().set_locale('pt_BR')
+        i18n.get_i18n().set_locale("pt_BR")
         value = datetime.datetime(2009, 11, 10, 16, 36, 5)
 
+        self.assertEqual(i18n.format_date(value, format="short"), "10/11/2009")
+        self.assertEqual(i18n.format_date(value, format="medium"), "10 de nov. de 2009")
         self.assertEqual(
-            i18n.format_date(value, format='short'),
-            u'10/11/09'
+            i18n.format_date(value, format="long"), "10 de novembro de 2009"
         )
         self.assertEqual(
-            i18n.format_date(value, format='medium'), u'10 de nov de 2009')
-        self.assertEqual(
-            i18n.format_date(value, format='long'),
-            u'10 de novembro de 2009'
-        )
-        self.assertEqual(
-            i18n.format_date(value, format='full'),
-            u'terça-feira, 10 de novembro de 2009'
+            i18n.format_date(value, format="full"),
+            "terça-feira, 10 de novembro de 2009",
         )
 
     def test_format_datetime(self):
         value = datetime.datetime(2009, 11, 10, 16, 36, 5)
 
         self.assertEqual(
-            i18n.format_datetime(value, format='short'),
-            u'11/10/09, 4:36 PM'
+            i18n.format_datetime(value, format="short"), "11/10/09, 4:36\u202fPM"
         )
         self.assertEqual(
-            i18n.format_datetime(value, format='medium'),
-            u'Nov 10, 2009, 4:36:05 PM'
+            i18n.format_datetime(value, format="medium"),
+            "Nov 10, 2009, 4:36:05\u202fPM",
         )
         self.assertEqual(
-            i18n.format_datetime(value, format='long'),
-            u'November 10, 2009 at 4:36:05 PM +0000'
+            i18n.format_datetime(value, format="long"),
+            "November 10, 2009, 4:36:05\u202fPM UTC",
         )
 
         # self.assertEqual(i18n.format_datetime(value, format='full'),
         # u'Tuesday, November 10, 2009 4:36:05 PM World (GMT) Time')
 
         self.assertEqual(
-            i18n.format_datetime(value, format='full'),
-            u'Tuesday, November 10, 2009 at 4:36:05 PM GMT+00:00'
+            i18n.format_datetime(value, format="full"),
+            "Tuesday, November 10, 2009, 4:36:05\u202fPM Coordinated Universal Time",
         )
 
-        i18n.get_i18n().set_timezone('America/Chicago')
+        i18n.get_i18n().set_timezone("America/Chicago")
         self.assertEqual(
-            i18n.format_datetime(value, format='short'),
-            u'11/10/09, 10:36 AM'
+            i18n.format_datetime(value, format="short"), "11/10/09, 10:36\u202fAM"
         )
 
     def test_format_datetime_no_format(self):
         value = datetime.datetime(2009, 11, 10, 16, 36, 5)
-        self.assertEqual(
-            i18n.format_datetime(value),
-            u'Nov 10, 2009, 4:36:05 PM'
-        )
+        self.assertEqual(i18n.format_datetime(value), "Nov 10, 2009, 4:36:05\u202fPM")
 
     def test_format_datetime_pt_BR(self):
-        i18n.get_i18n().set_locale('pt_BR')
+        i18n.get_i18n().set_locale("pt_BR")
         value = datetime.datetime(2009, 11, 10, 16, 36, 5)
 
         self.assertEqual(
-            i18n.format_datetime(value, format='short'),
-            u'10/11/09 16:36'
+            i18n.format_datetime(value, format="short"), "10/11/2009 16:36"
         )
         self.assertEqual(
-            i18n.format_datetime(value, format='medium'),
-            u'10 de nov de 2009 16:36:05'
+            i18n.format_datetime(value, format="medium"), "10 de nov. de 2009 16:36:05"
         )
         # self.assertEqual(i18n.format_datetime(value, format='long'),
         # u'10 de novembro de 2009 16:36:05 +0000')
         self.assertEqual(
-            i18n.format_datetime(value, format='long'),
-            u'10 de novembro de 2009 16:36:05 +0000'
+            i18n.format_datetime(value, format="long"),
+            "10 de novembro de 2009 16:36:05 UTC",
         )
         # self.assertEqual(i18n.format_datetime(value, format='full'),
         # u'terça-feira, 10 de novembro de 2009
         # 16h36min05s Horário Mundo (GMT)')
         self.assertEqual(
-            i18n.format_datetime(value, format='full'),
-            u'ter\xe7a-feira, 10 de novembro de 2009 16:36:05 GMT+00:00'
+            i18n.format_datetime(value, format="full"),
+            "ter\xe7a-feira, 10 de novembro de 2009 16:36:05 Horário Universal Coordenado",
         )
 
     def test_format_time(self):
         value = datetime.datetime(2009, 11, 10, 16, 36, 5)
 
-        self.assertEqual(i18n.format_time(value, format='short'), u'4:36 PM')
-        self.assertEqual(
-            i18n.format_time(value, format='medium'),
-            u'4:36:05 PM')
-        self.assertEqual(
-            i18n.format_time(value, format='long'),
-            u'4:36:05 PM +0000'
-        )
+        self.assertEqual(i18n.format_time(value, format="short"), "4:36\u202fPM")
+        self.assertEqual(i18n.format_time(value, format="medium"), "4:36:05\u202fPM")
+        self.assertEqual(i18n.format_time(value, format="long"), "4:36:05\u202fPM UTC")
         # self.assertEqual(i18n.format_time(value, format='full'),
         #  u'4:36:05 PM World (GMT) Time')
         self.assertEqual(
-            i18n.format_time(value, format='full'),
-            u'4:36:05 PM GMT+00:00'
+            i18n.format_time(value, format="full"),
+            "4:36:05\u202fPM Coordinated Universal Time",
         )
 
     def test_format_time_no_format(self):
         value = datetime.datetime(2009, 11, 10, 16, 36, 5)
-        self.assertEqual(i18n.format_time(value), u'4:36:05 PM')
+        self.assertEqual(i18n.format_time(value), "4:36:05\u202fPM")
 
     def test_format_time_pt_BR(self):
-        i18n.get_i18n().set_locale('pt_BR')
+        i18n.get_i18n().set_locale("pt_BR")
         value = datetime.datetime(2009, 11, 10, 16, 36, 5)
 
-        self.assertEqual(i18n.format_time(value, format='short'), u'16:36')
-        self.assertEqual(
-            i18n.format_time(value, format='medium'),
-            u'16:36:05'
-        )
+        self.assertEqual(i18n.format_time(value, format="short"), "16:36")
+        self.assertEqual(i18n.format_time(value, format="medium"), "16:36:05")
         # self.assertEqual(i18n.format_time(value, format='long'),
         #  u'16:36:05 +0000')
-        self.assertEqual(
-            i18n.format_time(value, format='long'),
-            u'16:36:05 +0000'
-        )
+        self.assertEqual(i18n.format_time(value, format="long"), "16:36:05 UTC")
         # self.assertEqual(i18n.format_time(value, format='full'),
         #  u'16h36min05s Horário Mundo (GMT)')
         self.assertEqual(
-            i18n.format_time(value, format='full'),
-            u'16:36:05 GMT+00:00')
-
-        i18n.get_i18n().set_timezone('America/Chicago')
-        self.assertEqual(i18n.format_time(value, format='short'), u'10:36')
-
-    def test_parse_date(self):
-        i18n.get_i18n().set_locale('en_US')
-        self.assertEqual(i18n.parse_date('4/1/04'), datetime.date(2004, 4, 1))
-        i18n.get_i18n().set_locale('de_DE')
-        self.assertEqual(
-            i18n.parse_date('01.04.2004'),
-            datetime.date(2004, 4, 1)
+            i18n.format_time(value, format="full"),
+            "16:36:05 Horário Universal Coordenado",
         )
 
+        i18n.get_i18n().set_timezone("America/Chicago")
+        self.assertEqual(i18n.format_time(value, format="short"), "10:36")
+
+    def test_parse_date(self):
+        i18n.get_i18n().set_locale("en_US")
+        self.assertEqual(i18n.parse_date("4/1/04"), datetime.date(2004, 4, 1))
+        i18n.get_i18n().set_locale("de_DE")
+        self.assertEqual(i18n.parse_date("01.04.2004"), datetime.date(2004, 4, 1))
+
     def test_parse_datetime(self):
-        i18n.get_i18n().set_locale('en_US')
-        self.assertRaises(
-            AttributeError, i18n.parse_datetime, '4/1/04 16:08:09')
+        i18n.get_i18n().set_locale("en_US")
+        self.assertEqual(
+            i18n.parse_datetime("4/1/04 16:08:09"),
+            datetime.datetime(2004, 4, 1, 16, 8, 9),
+        )
 
     def test_parse_time(self):
-        i18n.get_i18n().set_locale('en_US')
-        self.assertEqual(i18n.parse_time('18:08:09'), datetime.time(18, 8, 9))
-        i18n.get_i18n().set_locale('de_DE')
-        self.assertEqual(i18n.parse_time('18:08:09'), datetime.time(18, 8, 9))
+        i18n.get_i18n().set_locale("en_US")
+        self.assertEqual(i18n.parse_time("18:08:09"), datetime.time(18, 8, 9))
+        i18n.get_i18n().set_locale("de_DE")
+        self.assertEqual(i18n.parse_time("18:08:09"), datetime.time(18, 8, 9))
 
     def test_format_timedelta(self):
         # This is only present in Babel dev, so skip if not available.
-        if not getattr(i18n, 'format_timedelta', None):
+        if not getattr(i18n, "format_timedelta", None):
             return
 
-        i18n.get_i18n().set_locale('en_US')
+        i18n.get_i18n().set_locale("en_US")
 
         # self.assertEqual(
         # i18n.format_timedelta(datetime.timedelta(weeks=12)),
         # u'3 months')
 
         self.assertEqual(
-            i18n.format_timedelta(datetime.timedelta(weeks=12)),
-            u'3 months'
+            i18n.format_timedelta(datetime.timedelta(weeks=12)), "3 months"
         )
-        i18n.get_i18n().set_locale('es')
+        i18n.get_i18n().set_locale("es")
         # self.assertEqual(
         # i18n.format_timedelta(datetime.timedelta(seconds=1)),
         #  u'1 segundo'
         # )
         self.assertEqual(
-            i18n.format_timedelta(datetime.timedelta(seconds=1)),
-            u'1 segundo'
+            i18n.format_timedelta(datetime.timedelta(seconds=1)), "1 segundo"
         )
-        i18n.get_i18n().set_locale('en_US')
+        i18n.get_i18n().set_locale("en_US")
         self.assertEqual(
-            i18n.format_timedelta(datetime.timedelta(hours=3),
-                                  granularity='day'),
-            u'1 day'
+            i18n.format_timedelta(datetime.timedelta(hours=3), granularity="day"),
+            "1 day",
         )
         self.assertEqual(
-            i18n.format_timedelta(
-                datetime.timedelta(hours=23), threshold=0.9),
-            u'1 day'
+            i18n.format_timedelta(datetime.timedelta(hours=23), threshold=0.9), "1 day"
         )
         # self.assertEqual(i18n.format_timedelta(
         # datetime.timedelta(hours=23), threshold=1.1),
         #  u'23 hours'
         # )
         self.assertEqual(
-            i18n.format_timedelta(
-                datetime.timedelta(hours=23), threshold=1.1),
-            u'23 hours'
+            i18n.format_timedelta(datetime.timedelta(hours=23), threshold=1.1),
+            "23 hours",
         )
         self.assertEqual(
-            i18n.format_timedelta(
-                datetime.datetime.now() - datetime.timedelta(days=5)),
-            u'5 days'
+            i18n.format_timedelta(datetime.datetime.now() - datetime.timedelta(days=5)),
+            "5 days",
         )
 
     def test_format_iso(self):
         value = datetime.datetime(2009, 11, 10, 16, 36, 5)
 
-        self.assertEqual(i18n.format_date(value, format='iso'), u'2009-11-10')
-        self.assertEqual(i18n.format_time(value, format='iso'), u'16:36:05')
+        self.assertEqual(i18n.format_date(value, format="iso"), "2009-11-10")
+        self.assertEqual(i18n.format_time(value, format="iso"), "16:36:05")
         self.assertEqual(
-            i18n.format_datetime(value, format='iso'),
-            u'2009-11-10T16:36:05+0000'
+            i18n.format_datetime(value, format="iso"), "2009-11-10T16:36:05+0000"
         )
 
     # ==========================================================================
@@ -374,65 +325,65 @@ class I18nTestCase(unittest.TestCase):
     # ==========================================================================
 
     def test_set_timezone(self):
-        i18n.get_i18n().set_timezone('UTC')
-        self.assertEqual(i18n.get_i18n().tzinfo.zone, 'UTC')
+        i18n.get_i18n().set_timezone("UTC")
+        self.assertEqual(i18n.get_i18n().tzinfo.zone, "UTC")
 
-        i18n.get_i18n().set_timezone('America/Chicago')
-        self.assertEqual(i18n.get_i18n().tzinfo.zone, 'America/Chicago')
+        i18n.get_i18n().set_timezone("America/Chicago")
+        self.assertEqual(i18n.get_i18n().tzinfo.zone, "America/Chicago")
 
-        i18n.get_i18n().set_timezone('America/Sao_Paulo')
-        self.assertEqual(i18n.get_i18n().tzinfo.zone, 'America/Sao_Paulo')
+        i18n.get_i18n().set_timezone("America/Sao_Paulo")
+        self.assertEqual(i18n.get_i18n().tzinfo.zone, "America/Sao_Paulo")
 
     def test_to_local_timezone(self):
-        i18n.get_i18n().set_timezone('US/Eastern')
+        i18n.get_i18n().set_timezone("US/Eastern")
 
-        format = '%Y-%m-%d %H:%M:%S %Z%z'
+        format = "%Y-%m-%d %H:%M:%S %Z%z"
 
         # Test datetime with timezone set
         base = datetime.datetime(2002, 10, 27, 6, 0, 0, tzinfo=pytz.UTC)
         localtime = i18n.to_local_timezone(base)
         result = localtime.strftime(format)
-        self.assertEqual(result, '2002-10-27 01:00:00 EST-0500')
+        self.assertEqual(result, "2002-10-27 01:00:00 EST-0500")
 
         # Test naive datetime - no timezone set
         base = datetime.datetime(2002, 10, 27, 6, 0, 0)
         localtime = i18n.to_local_timezone(base)
         result = localtime.strftime(format)
-        self.assertEqual(result, '2002-10-27 01:00:00 EST-0500')
+        self.assertEqual(result, "2002-10-27 01:00:00 EST-0500")
 
     def test_to_utc(self):
-        i18n.get_i18n().set_timezone('US/Eastern')
+        i18n.get_i18n().set_timezone("US/Eastern")
 
-        format = '%Y-%m-%d %H:%M:%S'
+        format = "%Y-%m-%d %H:%M:%S"
 
         # Test datetime with timezone set
         base = datetime.datetime(2002, 10, 27, 6, 0, 0, tzinfo=pytz.UTC)
         localtime = i18n.to_utc(base)
         result = localtime.strftime(format)
 
-        self.assertEqual(result, '2002-10-27 06:00:00')
+        self.assertEqual(result, "2002-10-27 06:00:00")
 
         # Test naive datetime - no timezone set
         base = datetime.datetime(2002, 10, 27, 6, 0, 0)
         localtime = i18n.to_utc(base)
         result = localtime.strftime(format)
-        self.assertEqual(result, '2002-10-27 11:00:00')
+        self.assertEqual(result, "2002-10-27 11:00:00")
 
     def test_get_timezone_location(self):
-        i18n.get_i18n().set_locale('de_DE')
+        i18n.get_i18n().set_locale("de_DE")
         self.assertEqual(
-            i18n.get_timezone_location(pytz.timezone('America/St_Johns')),
-            u'Neufundland-Zeit'
+            i18n.get_timezone_location(pytz.timezone("America/St_Johns")),
+            "Neufundland-Zeit",
         )
-        i18n.get_i18n().set_locale('de_DE')
+        i18n.get_i18n().set_locale("de_DE")
         self.assertEqual(
-            i18n.get_timezone_location(pytz.timezone('America/Mexico_City')),
-            u'Nordamerikanische Inlandzeit'
+            i18n.get_timezone_location(pytz.timezone("America/Mexico_City")),
+            "Nordamerikanische Zentralzeit",
         )
-        i18n.get_i18n().set_locale('de_DE')
+        i18n.get_i18n().set_locale("de_DE")
         self.assertEqual(
-            i18n.get_timezone_location(pytz.timezone('Europe/Berlin')),
-            u'Mitteleurop\xe4ische Zeit'
+            i18n.get_timezone_location(pytz.timezone("Europe/Berlin")),
+            "Mitteleurop\xe4ische Zeit",
         )
 
     # ==========================================================================
@@ -440,87 +391,74 @@ class I18nTestCase(unittest.TestCase):
     # ==========================================================================
 
     def test_format_number(self):
-        i18n.get_i18n().set_locale('en_US')
-        self.assertEqual(i18n.format_number(1099), u'1,099')
+        i18n.get_i18n().set_locale("en_US")
+        self.assertEqual(i18n.format_number(1099), "1,099")
 
     def test_format_decimal(self):
-        i18n.get_i18n().set_locale('en_US')
-        self.assertEqual(i18n.format_decimal(1.2345), u'1.234')
-        self.assertEqual(i18n.format_decimal(1.2346), u'1.235')
-        self.assertEqual(i18n.format_decimal(-1.2346), u'-1.235')
-        self.assertEqual(i18n.format_decimal(12345.5), u'12,345.5')
+        i18n.get_i18n().set_locale("en_US")
+        self.assertEqual(i18n.format_decimal(1.2345), "1.234")
+        self.assertEqual(i18n.format_decimal(1.2346), "1.235")
+        self.assertEqual(i18n.format_decimal(-1.2346), "-1.235")
+        self.assertEqual(i18n.format_decimal(12345.5), "12,345.5")
 
-        i18n.get_i18n().set_locale('sv_SE')
-        self.assertEqual(i18n.format_decimal(1.2345), u'1,234')
+        i18n.get_i18n().set_locale("sv_SE")
+        self.assertEqual(i18n.format_decimal(1.2345), "1,234")
 
-        i18n.get_i18n().set_locale('de')
-        self.assertEqual(i18n.format_decimal(12345), u'12.345')
+        i18n.get_i18n().set_locale("de")
+        self.assertEqual(i18n.format_decimal(12345), "12.345")
 
     def test_format_currency(self):
-        i18n.get_i18n().set_locale('en_US')
-        self.assertEqual(i18n.format_currency(1099.98, 'USD'), u'$1,099.98')
+        i18n.get_i18n().set_locale("en_US")
+        self.assertEqual(i18n.format_currency(1099.98, "USD"), "$1,099.98")
         self.assertEqual(
-            i18n.format_currency(1099.98, 'EUR', u'\xa4\xa4 #,##0.00'),
-            u'EUR 1,099.98'
+            i18n.format_currency(1099.98, "EUR", "\xa4\xa4 #,##0.00"), "EUR 1,099.98"
         )
 
-        i18n.get_i18n().set_locale('es_CO')
-        self.assertEqual(
-            i18n.format_currency(1099.98, 'USD'),
-            u'US$\xa01.099,98'
-        )
+        i18n.get_i18n().set_locale("es_CO")
+        self.assertEqual(i18n.format_currency(1099.98, "USD"), "US$1.099,98")
 
-        i18n.get_i18n().set_locale('de_DE')
-        self.assertEqual(
-            i18n.format_currency(1099.98, 'EUR'),
-            u'1.099,98\xa0\u20ac'
-        )
+        i18n.get_i18n().set_locale("de_DE")
+        self.assertEqual(i18n.format_currency(1099.98, "EUR"), "1.099,98\xa0\u20ac")
 
     def test_format_percent(self):
-        i18n.get_i18n().set_locale('en_US')
-        self.assertEqual(i18n.format_percent(0.34), u'34%')
-        self.assertEqual(i18n.format_percent(25.1234), u'2,512%')
-        self.assertEqual(
-            i18n.format_percent(25.1234, u'#,##0\u2030'),
-            u'25,123\u2030'
-        )
+        i18n.get_i18n().set_locale("en_US")
+        self.assertEqual(i18n.format_percent(0.34), "34%")
+        self.assertEqual(i18n.format_percent(25.1234), "2,512%")
+        self.assertEqual(i18n.format_percent(25.1234, "#,##0\u2030"), "25,123\u2030")
 
-        i18n.get_i18n().set_locale('sv_SE')
-        self.assertEqual(i18n.format_percent(25.1234), u'2\xa0512\xa0%')
+        i18n.get_i18n().set_locale("sv_SE")
+        self.assertEqual(i18n.format_percent(25.1234), "2\xa0512\xa0%")
 
     def test_format_scientific(self):
-        i18n.get_i18n().set_locale('en_US')
-        self.assertEqual(i18n.format_scientific(10000), u'1E4')
-        self.assertEqual(
-            i18n.format_scientific(1234567, u'##0E00'),
-            u'1.23E06'
-        )
+        i18n.get_i18n().set_locale("en_US")
+        self.assertEqual(i18n.format_scientific(10000), "1E4")
+        self.assertEqual(i18n.format_scientific(1234567, "##0E00"), "1.234567E06")
 
     def test_parse_number(self):
-        i18n.get_i18n().set_locale('en_US')
-        self.assertEqual(i18n.parse_number('1,099'), 1099)
+        i18n.get_i18n().set_locale("en_US")
+        self.assertEqual(i18n.parse_number("1,099"), 1099)
 
-        i18n.get_i18n().set_locale('de_DE')
-        self.assertEqual(i18n.parse_number('1.099'), 1099)
+        i18n.get_i18n().set_locale("de_DE")
+        self.assertEqual(i18n.parse_number("1.099"), 1099)
 
     def test_parse_number2(self):
-        i18n.get_i18n().set_locale('de')
-        self.assertRaises(NumberFormatError, i18n.parse_number, '1.099,98')
+        i18n.get_i18n().set_locale("de")
+        self.assertRaises(NumberFormatError, i18n.parse_number, "1.099,98")
 
     def test_parse_decimal(self):
-        i18n.get_i18n().set_locale('en_US')
-        self.assertEqual(i18n.parse_decimal('1,099.98'), Decimal('1099.98'))
+        i18n.get_i18n().set_locale("en_US")
+        self.assertEqual(i18n.parse_decimal("1,099.98"), Decimal("1099.98"))
 
-        i18n.get_i18n().set_locale('de')
-        self.assertEqual(i18n.parse_decimal('1.099,98'), Decimal('1099.98'))
+        i18n.get_i18n().set_locale("de")
+        self.assertEqual(i18n.parse_decimal("1.099,98"), Decimal("1099.98"))
 
     def test_parse_decimal_error(self):
-        i18n.get_i18n().set_locale('de')
-        self.assertRaises(NumberFormatError, i18n.parse_decimal, '2,109,998')
+        i18n.get_i18n().set_locale("de")
+        self.assertRaises(NumberFormatError, i18n.parse_decimal, "2,109,998")
 
     def test_set_i18n_store(self):
         app = webapp2.WSGIApplication()
-        req = webapp2.Request.blank('/')
+        req = webapp2.Request.blank("/")
         req.app = app
         store = i18n.I18nStore(app)
 
@@ -532,7 +470,7 @@ class I18nTestCase(unittest.TestCase):
 
     def test_get_i18n_store(self):
         app = webapp2.WSGIApplication()
-        req = webapp2.Request.blank('/')
+        req = webapp2.Request.blank("/")
         req.app = app
         self.assertEqual(len(app.registry), 0)
         s = i18n.get_store(app=app)
@@ -541,7 +479,7 @@ class I18nTestCase(unittest.TestCase):
 
     def test_set_i18n(self):
         app = webapp2.WSGIApplication()
-        req = webapp2.Request.blank('/')
+        req = webapp2.Request.blank("/")
         req.app = app
         store = i18n.I18n(req)
 
@@ -555,7 +493,7 @@ class I18nTestCase(unittest.TestCase):
 
     def test_get_i18n(self):
         app = webapp2.WSGIApplication()
-        req = webapp2.Request.blank('/')
+        req = webapp2.Request.blank("/")
         req.app = app
         self.assertEqual(len(app.registry), 0)
         self.assertEqual(len(req.registry), 0)
@@ -565,13 +503,11 @@ class I18nTestCase(unittest.TestCase):
         self.assertTrue(isinstance(i, i18n.I18n))
 
     def test_set_locale_selector(self):
-        i18n.get_store().set_locale_selector(
-            'tests.resources.i18n.locale_selector')
+        i18n.get_store().set_locale_selector("tests.resources.i18n.locale_selector")
 
     def test_set_timezone_selector(self):
-        i18n.get_store().set_timezone_selector(
-            'tests.resources.i18n.timezone_selector')
+        i18n.get_store().set_timezone_selector("tests.resources.i18n.timezone_selector")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/extras_jinja2_test.py
+++ b/tests/extras_jinja2_test.py
@@ -34,8 +34,6 @@ class TestJinja2(unittest.TestCase):
                 'environment_args': {
                     'autoescape': True,
                     'extensions': [
-                        'jinja2.ext.autoescape',
-                        'jinja2.ext.with_',
                         'jinja2.ext.i18n',
                     ],
                 },

--- a/tests/handler_test.py
+++ b/tests/handler_test.py
@@ -16,6 +16,7 @@
 """
 Tests for webapp2 webapp2.RequestHandler
 """
+
 import os
 import sys
 import unittest
@@ -36,7 +37,7 @@ except ImportError:
 class BareHandler(object):
     def __init__(self, request, response):
         self.response = response
-        response.write('I am not a RequestHandler but I work.')
+        response.write("I am not a RequestHandler but I work.")
 
     def dispatch(self):
         return self.response
@@ -44,83 +45,83 @@ class BareHandler(object):
 
 class HomeHandler(webapp2.RequestHandler):
     def get(self, **kwargs):
-        self.response.out.write('home sweet home')
+        self.response.out.write("home sweet home")
 
     def post(self, **kwargs):
-        self.response.out.write('home sweet home - POST')
+        self.response.out.write("home sweet home - POST")
 
 
 class MethodsHandler(HomeHandler):
     def put(self, **kwargs):
-        self.response.out.write('home sweet home - PUT')
+        self.response.out.write("home sweet home - PUT")
 
     def delete(self, **kwargs):
-        self.response.out.write('home sweet home - DELETE')
+        self.response.out.write("home sweet home - DELETE")
 
     def head(self, **kwargs):
-        self.response.out.write('home sweet home - HEAD')
+        self.response.out.write("home sweet home - HEAD")
 
     def trace(self, **kwargs):
-        self.response.out.write('home sweet home - TRACE')
+        self.response.out.write("home sweet home - TRACE")
 
     def options(self, **kwargs):
-        self.response.out.write('home sweet home - OPTIONS')
+        self.response.out.write("home sweet home - OPTIONS")
 
 
 class RedirectToHandler(webapp2.RequestHandler):
     def get(self, **kwargs):
         return self.redirect_to(
-            'route-test',
-            _fragment='my-anchor',
-            year='2010',
-            month='07',
-            name='test',
-            foo='bar'
+            "route-test",
+            _fragment="my-anchor",
+            year="2010",
+            month="07",
+            name="test",
+            foo="bar",
         )
 
 
 class RedirectAbortHandler(webapp2.RequestHandler):
     def get(self, **kwargs):
-        self.response.headers.add_header('Set-Cookie', 'a=b')
-        self.redirect('/somewhere', abort=True)
+        self.response.headers.add_header("Set-Cookie", "a=b")
+        self.redirect("/somewhere", abort=True)
 
 
 class BrokenHandler(webapp2.RequestHandler):
     def get(self, **kwargs):
-        raise ValueError('booo!')
+        raise ValueError("booo!")
 
 
 class BrokenButFixedHandler(BrokenHandler):
     def handle_exception(self, exception, debug_mode):
         # Let's fix it.
         self.response.set_status(200)
-        self.response.out.write('that was close!')
+        self.response.out.write("that was close!")
 
 
 def handle_404(request, response, exception):
-    response.out.write('404 custom handler')
+    response.out.write("404 custom handler")
     response.set_status(404)
 
 
 def handle_405(request, response, exception):
-    response.out.write('405 custom handler')
-    response.set_status(405, 'Custom Error Message')
-    response.headers['Allow'] = 'GET'
+    response.out.write("405 custom handler")
+    response.set_status(405, "Custom Error Message")
+    response.headers["Allow"] = "GET"
 
 
 def handle_500(request, response, exception):
-    response.out.write('500 custom handler')
+    response.out.write("500 custom handler")
     response.set_status(500)
 
 
 class PositionalHandler(webapp2.RequestHandler):
     def get(self, month, day, slug=None):
-        self.response.out.write('%s:%s:%s' % (month, day, slug))
+        self.response.out.write("%s:%s:%s" % (month, day, slug))
 
 
 class HandlerWithError(webapp2.RequestHandler):
     def get(self, **kwargs):
-        self.response.out.write('bla bla bla bla bla bla')
+        self.response.out.write("bla bla bla bla bla bla")
         self.error(403)
 
 
@@ -129,23 +130,23 @@ class InitializeHandler(webapp2.RequestHandler):
         pass
 
     def get(self):
-        self.response.out.write('Request method: %s' % self.request.method)
+        self.response.out.write("Request method: %s" % self.request.method)
 
 
 class WebDavHandler(webapp2.RequestHandler):
     def version_control(self):
-        self.response.out.write('Method: VERSION-CONTROL')
+        self.response.out.write("Method: VERSION-CONTROL")
 
     def unlock(self):
-        self.response.out.write('Method: UNLOCK')
+        self.response.out.write("Method: UNLOCK")
 
     def propfind(self):
-        self.response.out.write('Method: PROPFIND')
+        self.response.out.write("Method: PROPFIND")
 
 
 class AuthorizationHandler(webapp2.RequestHandler):
     def get(self):
-        self.response.out.write('nothing here')
+        self.response.out.write("nothing here")
 
 
 class HandlerWithEscapedArg(webapp2.RequestHandler):
@@ -154,36 +155,49 @@ class HandlerWithEscapedArg(webapp2.RequestHandler):
 
 
 def get_redirect_url(handler, **kwargs):
-    return handler.uri_for('methods')
+    return handler.uri_for("methods")
 
 
-app = webapp2.WSGIApplication([
-    ('/bare', BareHandler),
-    webapp2.Route('/', HomeHandler, name='home'),
-    webapp2.Route('/methods', MethodsHandler, name='methods'),
-    webapp2.Route('/broken', BrokenHandler),
-    webapp2.Route('/broken-but-fixed', BrokenButFixedHandler),
-    webapp2.Route('/<year:\d{4}>/<month:\d{1,2}>/<name>', None,
-                  name='route-test'),
-    webapp2.Route('/<:\d\d>/<:\d{2}>/<:\w+>', PositionalHandler,
-                  name='positional'),
-    webapp2.Route('/redirect-me', webapp2.RedirectHandler,
-                  defaults={'_uri': '/broken'}),
-    webapp2.Route('/redirect-me2', webapp2.RedirectHandler,
-                  defaults={'_uri': get_redirect_url}),
-    webapp2.Route('/redirect-me3', webapp2.RedirectHandler,
-                  defaults={'_uri': '/broken', '_permanent': False}),
-    webapp2.Route('/redirect-me4', webapp2.RedirectHandler,
-                  defaults={'_uri': get_redirect_url, '_permanent': False}),
-    webapp2.Route('/redirect-me5', RedirectToHandler),
-    webapp2.Route('/redirect-me6', RedirectAbortHandler),
-    webapp2.Route('/lazy', 'tests.resources.handlers.LazyHandler'),
-    webapp2.Route('/error', HandlerWithError),
-    webapp2.Route('/initialize', InitializeHandler),
-    webapp2.Route('/webdav', WebDavHandler),
-    webapp2.Route('/authorization', AuthorizationHandler),
-    webapp2.Route('/escape/<name:.*>', HandlerWithEscapedArg, 'escape'),
-], debug=False)
+app = webapp2.WSGIApplication(
+    [
+        ("/bare", BareHandler),
+        webapp2.Route("/", HomeHandler, name="home"),
+        webapp2.Route("/methods", MethodsHandler, name="methods"),
+        webapp2.Route("/broken", BrokenHandler),
+        webapp2.Route("/broken-but-fixed", BrokenButFixedHandler),
+        webapp2.Route(r"/<year:\d{4}>/<month:\d{1,2}>/<name>", None, name="route-test"),
+        webapp2.Route(
+            r"/<:\d\d>/<:\d{2}>/<:\w+>", PositionalHandler, name="positional"
+        ),
+        webapp2.Route(
+            "/redirect-me", webapp2.RedirectHandler, defaults={"_uri": "/broken"}
+        ),
+        webapp2.Route(
+            "/redirect-me2",
+            webapp2.RedirectHandler,
+            defaults={"_uri": get_redirect_url},
+        ),
+        webapp2.Route(
+            "/redirect-me3",
+            webapp2.RedirectHandler,
+            defaults={"_uri": "/broken", "_permanent": False},
+        ),
+        webapp2.Route(
+            "/redirect-me4",
+            webapp2.RedirectHandler,
+            defaults={"_uri": get_redirect_url, "_permanent": False},
+        ),
+        webapp2.Route("/redirect-me5", RedirectToHandler),
+        webapp2.Route("/redirect-me6", RedirectAbortHandler),
+        webapp2.Route("/lazy", "tests.resources.handlers.LazyHandler"),
+        webapp2.Route("/error", HandlerWithError),
+        webapp2.Route("/initialize", InitializeHandler),
+        webapp2.Route("/webdav", WebDavHandler),
+        webapp2.Route("/authorization", AuthorizationHandler),
+        webapp2.Route("/escape/<name:.*>", HandlerWithEscapedArg, "escape"),
+    ],
+    debug=False,
+)
 
 DEFAULT_RESPONSE = """Status: 404 Not Found
 content-type: text/html; charset=utf8
@@ -202,57 +216,60 @@ class TestHandler(BaseTestCase):
         app.error_handlers = {}
 
     def test_200(self):
-        rsp = app.get_response('/')
+        rsp = app.get_response("/")
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'home sweet home')
+        self.assertEqual(rsp.body, b"home sweet home")
 
     def test_404(self):
-        req = webapp2.Request.blank('/nowhere')
+        req = webapp2.Request.blank("/nowhere")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 404)
 
     def test_405(self):
-        req = webapp2.Request.blank('/')
-        req.method = 'PUT'
+        req = webapp2.Request.blank("/")
+        req.method = "PUT"
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 405)
-        self.assertEqual(rsp.headers.get('Allow'), 'GET, POST')
+        self.assertEqual(rsp.headers.get("Allow"), "GET, POST")
 
     def test_500(self):
-        req = webapp2.Request.blank('/broken')
+        req = webapp2.Request.blank("/broken")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 500)
 
     def test_500_but_fixed(self):
-        req = webapp2.Request.blank('/broken-but-fixed')
+        req = webapp2.Request.blank("/broken-but-fixed")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'that was close!')
+        self.assertEqual(rsp.body, b"that was close!")
 
     def test_501(self):
         # 501 Not Implemented
-        req = webapp2.Request.blank('/methods')
-        req.method = 'FOOBAR'
+        req = webapp2.Request.blank("/methods")
+        req.method = "FOOBAR"
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 501)
 
     def test_lazy_handler(self):
-        req = webapp2.Request.blank('/lazy')
+        req = webapp2.Request.blank("/lazy")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'I am a laaazy view.')
+        self.assertEqual(rsp.body, b"I am a laaazy view.")
 
     def test_handler_with_error(self):
-        req = webapp2.Request.blank('/error')
+        req = webapp2.Request.blank("/error")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 403)
-        self.assertEqual(rsp.body, b'')
+        self.assertEqual(rsp.body, b"")
 
     def test_debug_mode(self):
-        app = webapp2.WSGIApplication([
-            webapp2.Route('/broken', BrokenHandler),
-        ], debug=True)
-        req = webapp2.Request.blank('/broken')
+        app = webapp2.WSGIApplication(
+            [
+                webapp2.Route("/broken", BrokenHandler),
+            ],
+            debug=True,
+        )
+        req = webapp2.Request.blank("/broken")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 500)
 
@@ -262,163 +279,146 @@ class TestHandler(BaseTestCase):
             405: handle_405,
             500: handle_500,
         }
-        req = webapp2.Request.blank('/nowhere')
+        req = webapp2.Request.blank("/nowhere")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 404)
-        self.assertEqual(rsp.body, b'404 custom handler')
+        self.assertEqual(rsp.body, b"404 custom handler")
 
-        req = webapp2.Request.blank('/')
-        req.method = 'PUT'
+        req = webapp2.Request.blank("/")
+        req.method = "PUT"
         rsp = req.get_response(app)
-        self.assertEqual(rsp.status, '405 Custom Error Message')
-        self.assertEqual(rsp.body, b'405 custom handler')
-        self.assertEqual(rsp.headers.get('Allow'), 'GET')
+        self.assertEqual(rsp.status, "405 Custom Error Message")
+        self.assertEqual(rsp.body, b"405 custom handler")
+        self.assertEqual(rsp.headers.get("Allow"), "GET")
 
-        req = webapp2.Request.blank('/broken')
+        req = webapp2.Request.blank("/broken")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 500)
-        self.assertEqual(rsp.body, b'500 custom handler')
+        self.assertEqual(rsp.body, b"500 custom handler")
 
     def test_methods(self):
         app.debug = True
-        req = webapp2.Request.blank('/methods')
+        req = webapp2.Request.blank("/methods")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'home sweet home')
+        self.assertEqual(rsp.body, b"home sweet home")
 
-        req = webapp2.Request.blank('/methods')
-        req.method = 'POST'
+        req = webapp2.Request.blank("/methods")
+        req.method = "POST"
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'home sweet home - POST')
+        self.assertEqual(rsp.body, b"home sweet home - POST")
 
-        req = webapp2.Request.blank('/methods')
-        req.method = 'PUT'
+        req = webapp2.Request.blank("/methods")
+        req.method = "PUT"
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'home sweet home - PUT')
+        self.assertEqual(rsp.body, b"home sweet home - PUT")
 
-        req = webapp2.Request.blank('/methods')
-        req.method = 'DELETE'
+        req = webapp2.Request.blank("/methods")
+        req.method = "DELETE"
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'home sweet home - DELETE')
+        self.assertEqual(rsp.body, b"home sweet home - DELETE")
 
-        req = webapp2.Request.blank('/methods')
-        req.method = 'HEAD'
+        req = webapp2.Request.blank("/methods")
+        req.method = "HEAD"
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'')
+        self.assertEqual(rsp.body, b"")
 
-        req = webapp2.Request.blank('/methods')
-        req.method = 'OPTIONS'
+        req = webapp2.Request.blank("/methods")
+        req.method = "OPTIONS"
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'home sweet home - OPTIONS')
+        self.assertEqual(rsp.body, b"home sweet home - OPTIONS")
 
-        req = webapp2.Request.blank('/methods')
-        req.method = 'TRACE'
+        req = webapp2.Request.blank("/methods")
+        req.method = "TRACE"
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'home sweet home - TRACE')
+        self.assertEqual(rsp.body, b"home sweet home - TRACE")
         app.debug = False
 
     def test_positional(self):
-        req = webapp2.Request.blank('/07/31/test')
+        req = webapp2.Request.blank("/07/31/test")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'07:31:test')
+        self.assertEqual(rsp.body, b"07:31:test")
 
-        req = webapp2.Request.blank('/10/18/wooohooo')
+        req = webapp2.Request.blank("/10/18/wooohooo")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'10:18:wooohooo')
+        self.assertEqual(rsp.body, b"10:18:wooohooo")
 
     def test_redirect(self):
-        req = webapp2.Request.blank('/redirect-me')
+        req = webapp2.Request.blank("/redirect-me")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 301)
-        self.assertEqual(rsp.body, b'')
-        self.assertEqual(rsp.headers['Location'], 'http://localhost/broken')
+        self.assertEqual(rsp.body, b"")
+        self.assertEqual(rsp.headers["Location"], "http://localhost/broken")
 
     def test_redirect_with_callable(self):
-        req = webapp2.Request.blank('/redirect-me2')
+        req = webapp2.Request.blank("/redirect-me2")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 301)
-        self.assertEqual(rsp.body, b'')
-        self.assertEqual(rsp.headers['Location'], 'http://localhost/methods')
+        self.assertEqual(rsp.body, b"")
+        self.assertEqual(rsp.headers["Location"], "http://localhost/methods")
 
     def test_redirect_not_permanent(self):
-        req = webapp2.Request.blank('/redirect-me3')
+        req = webapp2.Request.blank("/redirect-me3")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 302)
-        self.assertEqual(rsp.body, b'')
-        self.assertEqual(rsp.headers['Location'], 'http://localhost/broken')
+        self.assertEqual(rsp.body, b"")
+        self.assertEqual(rsp.headers["Location"], "http://localhost/broken")
 
     def test_redirect_with_callable_not_permanent(self):
-        req = webapp2.Request.blank('/redirect-me4')
+        req = webapp2.Request.blank("/redirect-me4")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 302)
-        self.assertEqual(rsp.body, b'')
-        self.assertEqual(rsp.headers['Location'], 'http://localhost/methods')
+        self.assertEqual(rsp.body, b"")
+        self.assertEqual(rsp.headers["Location"], "http://localhost/methods")
 
     def test_redirect_to(self):
-        req = webapp2.Request.blank('/redirect-me5')
+        req = webapp2.Request.blank("/redirect-me5")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 302)
-        self.assertEqual(rsp.body, b'')
+        self.assertEqual(rsp.body, b"")
         self.assertEqual(
-            rsp.headers['Location'],
-            'http://localhost/2010/07/test?foo=bar#my-anchor'
+            rsp.headers["Location"], "http://localhost/2010/07/test?foo=bar#my-anchor"
         )
 
     def test_redirect_abort(self):
-        req = webapp2.Request.blank('/redirect-me6')
+        req = webapp2.Request.blank("/redirect-me6")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 302)
         self.assertEqual(
             rsp.body,
             b"""302 Moved Temporarily\n\n"""
             b"""The resource was found at http://localhost/somewhere; """
-            b"""you should be redirected automatically.  """
+            b"""you should be redirected automatically.  """,
         )
-        self.assertEqual(rsp.headers['Location'], 'http://localhost/somewhere')
-        self.assertEqual(rsp.headers['Set-Cookie'], 'a=b')
+        self.assertEqual(rsp.headers["Location"], "http://localhost/somewhere")
+        self.assertEqual(rsp.headers["Set-Cookie"], "a=b")
 
     def test_run(self):
-        os.environ['REQUEST_METHOD'] = 'GET'
+        os.environ["REQUEST_METHOD"] = "GET"
 
-        with mock.patch('webapp2.handlers.sys.stdin') as patched_stdin:
-            with mock.patch('webapp2.handlers.sys.stdout') as patched_stdout:
-                patched_stdin.return_value = getattr(
-                    sys.stdin,
-                    'buffer',
-                    sys.stdin
-                )
-                patched_stdout.return_value = getattr(
-                    sys.stdout,
-                    'buffer',
-                    sys.stdout
-                )
+        with mock.patch("webapp2.handlers.sys.stdin") as patched_stdin:
+            with mock.patch("webapp2.handlers.sys.stdout") as patched_stdout:
+                patched_stdin.return_value = getattr(sys.stdin, "buffer", sys.stdin)
+                patched_stdout.return_value = getattr(sys.stdout, "buffer", sys.stdout)
 
                 app.run()
         # self.assertEqual(sys.stdout.read(), DEFAULT_RESPONSE)
 
     def test_run_bare(self):
-        os.environ['REQUEST_METHOD'] = 'GET'
+        os.environ["REQUEST_METHOD"] = "GET"
 
-        with mock.patch('webapp2.handlers.sys.stdin') as patched_stdin:
-            with mock.patch('webapp2.handlers.sys.stdout') as patched_stdout:
-                patched_stdin.return_value = getattr(
-                    sys.stdin,
-                    'buffer',
-                    sys.stdin
-                )
-                patched_stdout.return_value = getattr(
-                    sys.stdout,
-                    'buffer',
-                    sys.stdout
-                )
+        with mock.patch("webapp2.handlers.sys.stdin") as patched_stdin:
+            with mock.patch("webapp2.handlers.sys.stdout") as patched_stdout:
+                patched_stdin.return_value = getattr(sys.stdin, "buffer", sys.stdin)
+                patched_stdout.return_value = getattr(sys.stdout, "buffer", sys.stdout)
 
                 app.run(bare=True)
         # self.assertEqual(sys.stdout.read(), DEFAULT_RESPONSE)
@@ -426,28 +426,20 @@ class TestHandler(BaseTestCase):
     def test_run_debug(self):
         debug = app.debug
         app.debug = True
-        os.environ['REQUEST_METHOD'] = 'GET'
-        os.environ['PATH_INFO'] = '/'
+        os.environ["REQUEST_METHOD"] = "GET"
+        os.environ["PATH_INFO"] = "/"
 
-        with mock.patch('webapp2.handlers.sys.stdin') as patched_stdin:
-            with mock.patch('webapp2.handlers.sys.stdout') as patched_stdout:
-                patched_stdin.return_value = getattr(
-                    sys.stdin,
-                    'buffer',
-                    sys.stdin
-                )
-                patched_stdout.return_value = getattr(
-                    sys.stdout,
-                    'buffer',
-                    sys.stdout
-                )
+        with mock.patch("webapp2.handlers.sys.stdin") as patched_stdin:
+            with mock.patch("webapp2.handlers.sys.stdout") as patched_stdout:
+                patched_stdin.return_value = getattr(sys.stdin, "buffer", sys.stdin)
+                patched_stdout.return_value = getattr(sys.stdout, "buffer", sys.stdout)
 
                 app.run(bare=True)
         # self.assertEqual(sys.stdout.read(), DEFAULT_RESPONSE)
 
         app.debug = debug
 
-    '''
+    """
     def test_get_valid_methods(self):
         req = webapp2.Request.blank('http://localhost:80/')
         req.app = app
@@ -471,15 +463,15 @@ class TestHandler(BaseTestCase):
             handler.get_valid_methods().sort(),
             query_methods.sort()
         )
-    '''
+    """
 
     def test_uri_for(self):
         class Handler(webapp2.RequestHandler):
             def get(self, *args, **kwargs):
                 pass
 
-        req = webapp2.Request.blank('http://localhost:80/')
-        req.route = webapp2.Route('')
+        req = webapp2.Request.blank("http://localhost:80/")
+        req.route = webapp2.Route("")
         req.route_args = tuple()
         req.route_kwargs = {}
         req.app = app
@@ -488,134 +480,135 @@ class TestHandler(BaseTestCase):
         handler.app = app
 
         for func in (handler.uri_for,):
-            self.assertEqual(func('home'), '/')
-            self.assertEqual(func('home', foo='bar'), '/?foo=bar')
-            self.assertEqual(func('home', _fragment='my-anchor', foo='bar'),
-                             '/?foo=bar#my-anchor')
-            self.assertEqual(func('home', _fragment='my-anchor'),
-                             '/#my-anchor')
-            self.assertEqual(func('home', _full=True),
-                             'http://localhost:80/')
-            self.assertEqual(func('home', _full=True, _fragment='my-anchor'),
-                             'http://localhost:80/#my-anchor')
-            self.assertEqual(func('home', _scheme='https'),
-                             'https://localhost:80/')
-            self.assertEqual(func('home', _scheme='https', _full=False),
-                             'https://localhost:80/')
-            self.assertEqual(func('home',
-                                  _scheme='https',
-                                  _fragment='my-anchor'),
-                             'https://localhost:80/#my-anchor')
-
-            self.assertEqual(func('methods'), '/methods')
-            self.assertEqual(func('methods', foo='bar'), '/methods?foo=bar')
-            self.assertEqual(func('methods',
-                                  _fragment='my-anchor', foo='bar'),
-                             '/methods?foo=bar#my-anchor')
+            self.assertEqual(func("home"), "/")
+            self.assertEqual(func("home", foo="bar"), "/?foo=bar")
             self.assertEqual(
-                func('methods', _fragment='my-anchor'),
-                '/methods#my-anchor'
+                func("home", _fragment="my-anchor", foo="bar"), "/?foo=bar#my-anchor"
+            )
+            self.assertEqual(func("home", _fragment="my-anchor"), "/#my-anchor")
+            self.assertEqual(func("home", _full=True), "http://localhost:80/")
+            self.assertEqual(
+                func("home", _full=True, _fragment="my-anchor"),
+                "http://localhost:80/#my-anchor",
+            )
+            self.assertEqual(func("home", _scheme="https"), "https://localhost:80/")
+            self.assertEqual(
+                func("home", _scheme="https", _full=False), "https://localhost:80/"
             )
             self.assertEqual(
-                func('methods', _full=True),
-                'http://localhost:80/methods'
-            )
-            self.assertEqual(
-                func('methods', _full=True, _fragment='my-anchor'),
-                'http://localhost:80/methods#my-anchor'
-            )
-            self.assertEqual(
-                func('methods', _scheme='https'),
-                'https://localhost:80/methods'
-            )
-            self.assertEqual(func('methods', _scheme='https', _full=False),
-                             'https://localhost:80/methods')
-            self.assertEqual(
-                func('methods', _scheme='https', _fragment='my-anchor'),
-                'https://localhost:80/methods#my-anchor'
+                func("home", _scheme="https", _fragment="my-anchor"),
+                "https://localhost:80/#my-anchor",
             )
 
+            self.assertEqual(func("methods"), "/methods")
+            self.assertEqual(func("methods", foo="bar"), "/methods?foo=bar")
             self.assertEqual(
-                func('route-test', year='2010', month='0', name='test'),
-                '/2010/0/test'
+                func("methods", _fragment="my-anchor", foo="bar"),
+                "/methods?foo=bar#my-anchor",
             )
             self.assertEqual(
-                func('route-test', year='2010', month='07', name='test'),
-                '/2010/07/test'
+                func("methods", _fragment="my-anchor"), "/methods#my-anchor"
+            )
+            self.assertEqual(func("methods", _full=True), "http://localhost:80/methods")
+            self.assertEqual(
+                func("methods", _full=True, _fragment="my-anchor"),
+                "http://localhost:80/methods#my-anchor",
             )
             self.assertEqual(
-                func('route-test',
-                     year='2010', month='07', name='test', foo='bar'),
-                '/2010/07/test?foo=bar'
+                func("methods", _scheme="https"), "https://localhost:80/methods"
             )
             self.assertEqual(
-                func('route-test',
-                     _fragment='my-anchor',
-                     year='2010',
-                     month='07',
-                     name='test',
-                     foo='bar'),
-                '/2010/07/test?foo=bar#my-anchor'
+                func("methods", _scheme="https", _full=False),
+                "https://localhost:80/methods",
             )
             self.assertEqual(
-                func('route-test',
-                     _fragment='my-anchor',
-                     year='2010',
-                     month='07',
-                     name='test'),
-                '/2010/07/test#my-anchor'
+                func("methods", _scheme="https", _fragment="my-anchor"),
+                "https://localhost:80/methods#my-anchor",
+            )
+
+            self.assertEqual(
+                func("route-test", year="2010", month="0", name="test"), "/2010/0/test"
             )
             self.assertEqual(
-                func('route-test',
-                     _full=True,
-                     year='2010',
-                     month='07',
-                     name='test'),
-                'http://localhost:80/2010/07/test'
+                func("route-test", year="2010", month="07", name="test"),
+                "/2010/07/test",
             )
             self.assertEqual(
-                func('route-test',
-                     _full=True,
-                     _fragment='my-anchor',
-                     year='2010',
-                     month='07',
-                     name='test'),
-                'http://localhost:80/2010/07/test#my-anchor'
+                func("route-test", year="2010", month="07", name="test", foo="bar"),
+                "/2010/07/test?foo=bar",
             )
             self.assertEqual(
-                func('route-test',
-                     _scheme='https',
-                     year='2010',
-                     month='07',
-                     name='test'),
-                'https://localhost:80/2010/07/test'
+                func(
+                    "route-test",
+                    _fragment="my-anchor",
+                    year="2010",
+                    month="07",
+                    name="test",
+                    foo="bar",
+                ),
+                "/2010/07/test?foo=bar#my-anchor",
             )
             self.assertEqual(
-                func('route-test',
-                     _scheme='https',
-                     _full=False,
-                     year='2010',
-                     month='07',
-                     name='test'),
-                'https://localhost:80/2010/07/test'
+                func(
+                    "route-test",
+                    _fragment="my-anchor",
+                    year="2010",
+                    month="07",
+                    name="test",
+                ),
+                "/2010/07/test#my-anchor",
             )
             self.assertEqual(
-                func('route-test',
-                     _scheme='https',
-                     _fragment='my-anchor',
-                     year='2010',
-                     month='07',
-                     name='test'),
-                'https://localhost:80/2010/07/test#my-anchor'
+                func("route-test", _full=True, year="2010", month="07", name="test"),
+                "http://localhost:80/2010/07/test",
+            )
+            self.assertEqual(
+                func(
+                    "route-test",
+                    _full=True,
+                    _fragment="my-anchor",
+                    year="2010",
+                    month="07",
+                    name="test",
+                ),
+                "http://localhost:80/2010/07/test#my-anchor",
+            )
+            self.assertEqual(
+                func(
+                    "route-test", _scheme="https", year="2010", month="07", name="test"
+                ),
+                "https://localhost:80/2010/07/test",
+            )
+            self.assertEqual(
+                func(
+                    "route-test",
+                    _scheme="https",
+                    _full=False,
+                    year="2010",
+                    month="07",
+                    name="test",
+                ),
+                "https://localhost:80/2010/07/test",
+            )
+            self.assertEqual(
+                func(
+                    "route-test",
+                    _scheme="https",
+                    _fragment="my-anchor",
+                    year="2010",
+                    month="07",
+                    name="test",
+                ),
+                "https://localhost:80/2010/07/test#my-anchor",
             )
 
     def test_extra_request_methods(self):
         allowed_methods_backup = app.allowed_methods
-        webdav_methods = ('VERSION-CONTROL', 'UNLOCK', 'PROPFIND')
+        webdav_methods = ("VERSION-CONTROL", "UNLOCK", "PROPFIND")
 
         for method in webdav_methods:
             # It is still not possible to use WebDav methods...
-            req = webapp2.Request.blank('/webdav')
+            req = webapp2.Request.blank("/webdav")
             req.method = method
             rsp = req.get_response(app)
             self.assertEqual(rsp.status_int, 501)
@@ -629,11 +622,11 @@ class TestHandler(BaseTestCase):
 
         # Now we can use WebDav methods...
         for method in webdav_methods:
-            req = webapp2.Request.blank('/webdav')
+            req = webapp2.Request.blank("/webdav")
             req.method = method
             rsp = req.get_response(app)
             self.assertEqual(rsp.status_int, 200)
-            self.assertEqual(rsp.body, webapp2._to_utf8('Method: %s' % method))
+            self.assertEqual(rsp.body, webapp2._to_utf8("Method: %s" % method))
 
         # Restore initial values.
         app.allowed_methods = allowed_methods_backup
@@ -647,26 +640,26 @@ class TestHandler(BaseTestCase):
             handler.app = req.app = app
             return req, handler
 
-        req, handler = get_req('http://localhost:80/')
-        uri = webapp2.uri_for('escape', name='with space')
+        req, handler = get_req("http://localhost:80/")
+        uri = webapp2.uri_for("escape", name="with space")
         req, handler = get_req(uri)
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'with space')
+        self.assertEqual(rsp.body, b"with space")
 
-        req, handler = get_req('http://localhost:80/')
-        uri = webapp2.uri_for('escape', name='with+plus')
+        req, handler = get_req("http://localhost:80/")
+        uri = webapp2.uri_for("escape", name="with+plus")
         req, handler = get_req(uri)
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'with plus')
+        self.assertEqual(rsp.body, b"with plus")
 
-        req, handler = get_req('http://localhost:80/')
-        uri = webapp2.uri_for('escape', name='with/slash')
+        req, handler = get_req("http://localhost:80/")
+        uri = webapp2.uri_for("escape", name="with/slash")
         req, handler = get_req(uri)
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'with/slash')
+        self.assertEqual(rsp.body, b"with/slash")
 
     def test_handle_exception_with_error(self):
         class HomeHandler(webapp2.RequestHandler):
@@ -676,12 +669,15 @@ class TestHandler(BaseTestCase):
         def handle_exception(request, response, exception):
             raise ValueError()
 
-        app = webapp2.WSGIApplication([
-            webapp2.Route('/', HomeHandler, name='home'),
-        ], debug=False)
+        app = webapp2.WSGIApplication(
+            [
+                webapp2.Route("/", HomeHandler, name="home"),
+            ],
+            debug=False,
+        )
         app.error_handlers[500] = handle_exception
 
-        req = webapp2.Request.blank('/')
+        req = webapp2.Request.blank("/")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 500)
 
@@ -693,117 +689,128 @@ class TestHandler(BaseTestCase):
         def handle_exception(request, response, exception):
             raise ValueError()
 
-        app = webapp2.WSGIApplication([
-            webapp2.Route('/', HomeHandler, name='home'),
-        ], debug=True)
+        app = webapp2.WSGIApplication(
+            [
+                webapp2.Route("/", HomeHandler, name="home"),
+            ],
+            debug=True,
+        )
         app.error_handlers[500] = handle_exception
 
-        req = webapp2.Request.blank('/')
+        req = webapp2.Request.blank("/")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 500)
 
     def test_function_handler(self):
         def my_view(request, *args, **kwargs):
-            return webapp2.Response('Hello, function world!')
+            return webapp2.Response("Hello, function world!")
 
         def other_view(request, *args, **kwargs):
-            return webapp2.Response('Hello again, function world!')
+            return webapp2.Response("Hello again, function world!")
 
         def one_more_view(request, *args, **kwargs):
             self.assertEqual(args, ())
-            self.assertEqual(kwargs, {'foo': 'bar'})
-            return webapp2.Response('Hello you too!')
+            self.assertEqual(kwargs, {"foo": "bar"})
+            return webapp2.Response("Hello you too!")
 
-        app = webapp2.WSGIApplication([
-            webapp2.Route('/', my_view),
-            webapp2.Route('/other', other_view),
-            webapp2.Route('/one-more/<foo>', one_more_view)
-        ])
+        app = webapp2.WSGIApplication(
+            [
+                webapp2.Route("/", my_view),
+                webapp2.Route("/other", other_view),
+                webapp2.Route("/one-more/<foo>", one_more_view),
+            ]
+        )
 
-        req = webapp2.Request.blank('/')
+        req = webapp2.Request.blank("/")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'Hello, function world!')
+        self.assertEqual(rsp.body, b"Hello, function world!")
 
         # Twice to test factory.
-        req = webapp2.Request.blank('/')
+        req = webapp2.Request.blank("/")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'Hello, function world!')
+        self.assertEqual(rsp.body, b"Hello, function world!")
 
-        req = webapp2.Request.blank('/other')
+        req = webapp2.Request.blank("/other")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'Hello again, function world!')
+        self.assertEqual(rsp.body, b"Hello again, function world!")
 
         # Twice to test factory.
-        req = webapp2.Request.blank('/other')
+        req = webapp2.Request.blank("/other")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'Hello again, function world!')
+        self.assertEqual(rsp.body, b"Hello again, function world!")
 
-        req = webapp2.Request.blank('/one-more/bar')
+        req = webapp2.Request.blank("/one-more/bar")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'Hello you too!')
+        self.assertEqual(rsp.body, b"Hello you too!")
 
     def test_custom_method(self):
         class MyHandler(webapp2.RequestHandler):
             def my_method(self):
-                self.response.out.write('Hello, custom method world!')
+                self.response.out.write("Hello, custom method world!")
 
             def my_other_method(self):
-                self.response.out.write('Hello again, custom method world!')
+                self.response.out.write("Hello again, custom method world!")
 
-        app = webapp2.WSGIApplication([
-            webapp2.Route('/', MyHandler, handler_method='my_method'),
-            webapp2.Route('/other', MyHandler,
-                          handler_method='my_other_method'),
-        ])
+        app = webapp2.WSGIApplication(
+            [
+                webapp2.Route("/", MyHandler, handler_method="my_method"),
+                webapp2.Route("/other", MyHandler, handler_method="my_other_method"),
+            ]
+        )
 
-        req = webapp2.Request.blank('/')
+        req = webapp2.Request.blank("/")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'Hello, custom method world!')
+        self.assertEqual(rsp.body, b"Hello, custom method world!")
 
-        req = webapp2.Request.blank('/other')
+        req = webapp2.Request.blank("/other")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'Hello again, custom method world!')
+        self.assertEqual(rsp.body, b"Hello again, custom method world!")
 
     def test_custom_method_with_string(self):
-        handler = 'tests.resources.handlers.CustomMethodHandler:custom_method'
+        handler = "tests.resources.handlers.CustomMethodHandler:custom_method"
 
-        app = webapp2.WSGIApplication([
-            webapp2.Route('/', handler=handler),
-            webapp2.Route('/bleh', handler=handler),
-        ])
+        app = webapp2.WSGIApplication(
+            [
+                webapp2.Route("/", handler=handler),
+                webapp2.Route("/bleh", handler=handler),
+            ]
+        )
 
-        req = webapp2.Request.blank('/')
+        req = webapp2.Request.blank("/")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'I am a custom method.')
+        self.assertEqual(rsp.body, b"I am a custom method.")
 
-        req = webapp2.Request.blank('/bleh')
+        req = webapp2.Request.blank("/bleh")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'I am a custom method.')
+        self.assertEqual(rsp.body, b"I am a custom method.")
 
         self.assertRaises(
-            ValueError, webapp2.Route, '/',
+            ValueError,
+            webapp2.Route,
+            "/",
             handler=handler,
-            handler_method='custom_method'
+            handler_method="custom_method",
         )
 
     def test_factory_1(self):
         app.debug = True
-        rsp = app.get_response('/bare')
+        rsp = app.get_response("/bare")
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'I am not a RequestHandler but I work.')
+        self.assertEqual(rsp.body, b"I am not a RequestHandler but I work.")
         app.debug = False
 
     def test_factory_2(self):
         """Very crazy stuff. Please ignore it."""
+
         class MyHandler(object):
             def __init__(self, request, response):
                 self.request = request
@@ -824,50 +831,56 @@ class TestHandler(BaseTestCase):
                 return self
 
             def dispatch(self):
-                self.response.write('hello')
+                self.response.write("hello")
 
-        app = webapp2.WSGIApplication([
-            webapp2.Route('/', handler=MyHandler),
-        ])
+        app = webapp2.WSGIApplication(
+            [
+                webapp2.Route("/", handler=MyHandler),
+            ]
+        )
 
-        req = webapp2.Request.blank('/')
+        req = webapp2.Request.blank("/")
         rsp = req.get_response(app)
         self.assertEqual(rsp.status_int, 200)
-        self.assertEqual(rsp.body, b'hello')
+        self.assertEqual(rsp.body, b"hello")
 
     def test_encoding(self):
         class PostHandler(webapp2.RequestHandler):
             def post(self):
-                foo = self.request.POST['foo']
+                foo = self.request.POST["foo"]
                 if not foo:
-                    foo = 'empty'
+                    foo = "empty"
 
                 self.response.write(foo)
 
-        app = webapp2.WSGIApplication([
-            webapp2.Route('/', PostHandler),
-        ], debug=True)
+        app = webapp2.WSGIApplication(
+            [
+                webapp2.Route("/", PostHandler),
+            ],
+            debug=True,
+        )
 
         # foo with umlauts in the vowels.
-        value = b'f\xc3\xb6\xc3\xb6'
+        value = b"f\xc3\xb6\xc3\xb6"
 
         rsp = app.get_response(
-            '/',
-            POST={'foo': value},
-            headers=[('Content-Type',
-                      'application/x-www-form-urlencoded; charset=utf-8')]
+            "/",
+            POST={"foo": value},
+            headers=[
+                ("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+            ],
         )
-        self.assertEqual(rsp.unicode_body, u'föö')
+        self.assertEqual(rsp.unicode_body, "föö")
         self.assertEqual(rsp.body, value)
 
         rsp = app.get_response(
-            '/',
-            POST={'foo': value},
-            headers=[('Content-Type', 'application/x-www-form-urlencoded')]
+            "/",
+            POST={"foo": value},
+            headers=[("Content-Type", "application/x-www-form-urlencoded")],
         )
-        self.assertEqual(rsp.unicode_body, u'föö')
+        self.assertEqual(rsp.unicode_body, "föö")
         self.assertEqual(rsp.body, value)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/resources/jinja2_templates_compiled/tmpl_3a79873b1b49be244fd5444b1258ce348be26de8.py
+++ b/tests/resources/jinja2_templates_compiled/tmpl_3a79873b1b49be244fd5444b1258ce348be26de8.py
@@ -1,16 +1,16 @@
 from __future__ import division
 
-from jinja2.runtime import to_string
+from jinja2.runtime import str_join
 
 
-name = 'template1.html'
+name = "template1.html"
 
 
 def root(context):
-    l_message = context.resolve('message')
+    l_message = context.resolve("message")
     if 0:
         yield None
-    yield to_string(l_message)
+    yield str_join([l_message])
 
 
 blocks = {}

--- a/tests/test_jinja2_fix/build_and_test.sh
+++ b/tests/test_jinja2_fix/build_and_test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# build_and_test.sh
+
+echo "🔧 Building custom webapp2..."
+python -m pip install -e .
+
+echo "🧪 Running compatibility test for autoescape==True ..."
+python ./tests/test_jinja2_fix/test_jinja2_escape_fix.py
+
+echo "🧪 Running compatibility test for autoescape==False ..."
+python ./tests/test_jinja2_fix/test_jinja2_escape_fix.py
+
+echo "🎉 If you see ✅ above, you're golden!"

--- a/tests/test_jinja2_fix/test_jinja2_escape_fix.py
+++ b/tests/test_jinja2_fix/test_jinja2_escape_fix.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# test_jinja2_fix.py
+
+import webapp2
+from webapp2_extras import jinja2
+
+# Test basic functionality
+app = webapp2.WSGIApplication([])
+j2 = jinja2.Jinja2(app)
+
+# Test template rendering
+try:
+    template_str = j2.environment.from_string("Hello {{ name }}!")
+    result = template_str.render(name="webapp2 3.x")
+    print(f"✅ Success: {result}") # noqa
+
+    # Test autoescape
+    template_str = j2.environment.from_string("Hello {{ name }}!")
+    result = template_str.render(name="<script>alert('xss')</script>")
+    print(f"✅ Autoescape test: {result}") # noqa
+
+except Exception as e:
+    print(f"❌ Error: {e}") # noqa

--- a/tests/test_jinja2_fix/test_jinja2_unescape_fix.py
+++ b/tests/test_jinja2_fix/test_jinja2_unescape_fix.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# test_jinja2_fix.py
+
+import webapp2
+from webapp2_extras import jinja2
+
+# Test basic functionality
+app = webapp2.WSGIApplication([])
+j2 = jinja2.Jinja2(app)
+
+# Test template rendering
+try:
+    template_str = j2.environment.from_string("Hello {{ name }}!")
+    result = template_str.render(name="webapp2 3.x")
+    print(f"✅ Success: {result}") # noqa
+
+    # Test autoescape
+    template_str = j2.environment.from_string("Hello {{ name }}!")
+    result = template_str.render(name="<script>alert('xss')</script>")
+    print(f"✅ Autoescape test: {result}") # noqa
+
+except Exception as e:
+    print(f"❌ Error: {e}") # noqa

--- a/webapp2_extras/auth.py
+++ b/webapp2_extras/auth.py
@@ -263,7 +263,7 @@ class AuthStore(object):
         """
         try:
             assert len(data) >= len(self.session_attributes)
-            return dict(zip(self.session_attributes, data))
+            return dict(zip(self.session_attributes, data, strict=False))
         except AssertionError:
             logging.warning(
                 'Invalid user data: %r. Expected attributes: %r.' %

--- a/webapp2_extras/i18n.py
+++ b/webapp2_extras/i18n.py
@@ -32,11 +32,6 @@ import six
 
 import webapp2
 
-try:
-    # Monkeypatches pytz for gae.
-    import pytz.gae
-except ImportError:  # pragma: no cover
-    pass
 
 #: Default configuration values for this module. Keys are:
 #:
@@ -351,7 +346,7 @@ class I18n(object):
         if format is None:
             format = self.store.date_formats.get(key)
 
-        if format in ('short', 'medium', 'full', 'long', 'iso'):
+        if format in {'short', 'medium', 'full', 'long', 'iso'}:
             rv = self.store.date_formats.get('%s.%s' % (key, format))
             if rv is not None:
                 format = rv
@@ -613,15 +608,17 @@ class I18n(object):
     def parse_datetime(self, string):
         """Parses a date and time from a string.
 
-        This function uses the date and time formats for the locale as a hint
-        to determine the order in which the time fields appear in the string.
+        raceves: This function has been overwritten to use python-dateutil
+                 since parse_datetime was removed from babel. The locale is no
+                 longer used.
 
         :param string:
             The string containing the date and time.
         :returns:
             The parsed datetime object.
         """
-        return dates.parse_datetime(string, locale=self.locale)
+        from dateutil import parser
+        return parser.parse(string)
 
     def parse_time(self, string):
         """Parses a time from a string.

--- a/webapp2_extras/jinja2.py
+++ b/webapp2_extras/jinja2.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2011 webapp2 AUTHORS.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,11 +20,28 @@ Jinja2 template support for webapp2.
 
 Learn more about Jinja2: http://jinja.pocoo.org/
 """
-import importlib
-
 import webapp2
+from jinja2 import Environment, FileSystemLoader, ModuleLoader
 
-_jinja2 = importlib.import_module("jinja2")
+try:
+    from jinja2 import select_autoescape # noqa
+    _HAS_SELECT_AUTOESCAPE = True
+except ImportError:
+    _HAS_SELECT_AUTOESCAPE = False
+
+
+def _get_jinja2_version():
+    """Get the Jinja2 version for compatibility checks."""
+    try:
+        import jinja2
+        return tuple(map(int, jinja2.__version__.split('.')[:2]))
+    except (AttributeError, ValueError):
+        return 2, 8  # Assume old version if we can't determine
+
+
+# Check if we're using Jinja2 3.x
+_JINJA2_VERSION = _get_jinja2_version()
+_IS_JINJA2_3X = _JINJA2_VERSION >= (3, 0)
 
 
 #: Default configuration values for this module. Keys are:
@@ -43,8 +59,7 @@ _jinja2 = importlib.import_module("jinja2")
 #:
 #: environment_args
 #:     Keyword arguments used to instantiate the Jinja2 environment. By
-#:     default autoescaping is enabled and two extensions are set:
-#:     ``jinja2.ext.autoescape`` and ``jinja2.ext.with_``. For production it
+#:     default autoescaping is enabled. For production it
 #:     may be a good idea to set 'auto_reload' to False -- we don't need to
 #:     check if templates changed after deployed.
 #:
@@ -53,23 +68,37 @@ _jinja2 = importlib.import_module("jinja2")
 #:
 #: filters
 #:     Extra filters for the Jinja2 environment.
-default_config = {
-    'template_path': 'templates',
-    'compiled_path': None,
-    'force_compiled': False,
-    'environment_args': {
-        'autoescape': True,
-        'extensions': [
-            'jinja2.ext.autoescape',
-            'jinja2.ext.with_',
-        ],
-    },
-    'globals': None,
-    'filters': None,
-}
+
+# Dynamic default config based on Jinja2 version
+def _get_default_config():
+    base_config = {
+        'template_path': 'templates',
+        'force_compiled': False,
+        'globals': None,
+        'filters': None,
+        'compiled_path': None,
+    }
+
+    if _IS_JINJA2_3X:
+        # Jinja2 3.x configuration
+        base_config['environment_args'] = {
+            'autoescape': True,
+            'extensions': [],
+        }
+    else:
+        # Legacy Jinja2 2.x configuration
+        base_config['environment_args'] = {
+            'autoescape': True,
+            'extensions': ['jinja2.ext.autoescape', 'jinja2.ext.with_']
+        }
+
+    return base_config
 
 
-class Jinja2(object):
+default_config = _get_default_config()
+
+
+class Jinja2:
     """Wrapper for configurable and cached Jinja2 environment.
 
     To used it, set it as a cached property in a base `RequestHandler`::
@@ -122,6 +151,22 @@ class Jinja2(object):
         kwargs = config['environment_args'].copy()
         enable_i18n = 'jinja2.ext.i18n' in kwargs.get('extensions', [])
 
+        # Handle autoescape for Jinja2 3.x
+        if 'autoescape' in kwargs and kwargs['autoescape'] is True:
+            # Jinja2 3.x prefers select_autoescape for better control
+            from jinja2 import select_autoescape
+            try:
+                kwargs['autoescape'] = select_autoescape(['html', 'xml'])
+            except ImportError:
+                # Fallback for older versions
+                kwargs['autoescape'] = True
+
+        # Clean up extensions that are now built-in
+        extensions = kwargs.get('extensions', [])
+        # Remove extensions that are now built-in in Jinja2 3.x
+        cleaned_extensions = [ext for ext in extensions if ext not in {'jinja2.ext.autoescape', 'jinja2.ext.with_'}]
+        kwargs['extensions'] = cleaned_extensions
+
         if 'loader' not in kwargs:
             template_path = config['template_path']
             compiled_path = config['compiled_path']
@@ -129,13 +174,13 @@ class Jinja2(object):
 
             if compiled_path and use_compiled:
                 # Use precompiled templates loaded from a module or zip.
-                kwargs['loader'] = _jinja2.ModuleLoader(compiled_path)
+                kwargs['loader'] = ModuleLoader(compiled_path)
             else:
                 # Parse templates for every new environment instances.
-                kwargs['loader'] = _jinja2.FileSystemLoader(template_path)
+                kwargs['loader'] = FileSystemLoader(template_path)
 
         # Initialize the environment.
-        env = _jinja2.Environment(**kwargs)
+        env = Environment(**kwargs)
 
         if config['globals']:
             env.globals.update(config['globals'])
@@ -147,8 +192,8 @@ class Jinja2(object):
             # Install i18n.
             from webapp2_extras import i18n
             env.install_gettext_callables(
-                lambda x: i18n.gettext(x),
-                lambda s, p, n: i18n.ngettext(s, p, n),
+                i18n.gettext,
+                i18n.ngettext,
                 newstyle=True)
             env.filters.update({
                 'format_date':      i18n.format_date,


### PR DESCRIPTION
- Removed `gaepytz` - pytz is built into AppEngine nowadays.
- Upgraded all dependencies to their latest versions where able.
- Using dateutil.parser to parse datetime types since that feature is no longer apart of Babel.
- Remove jinja extensions `jinja2.ext.autoescape` (built in now) and `jinja2.ext.with_` (no longer exists)